### PR TITLE
fix(connector-azuread): officeLocation attribute bug fix

### DIFF
--- a/packages/connector-azuread/src/types.ts
+++ b/packages/connector-azuread/src/types.ts
@@ -26,7 +26,7 @@ export const userInfoResponseGuard = z.object({
   jobTitle: z.string().nullish(),
   mail: z.string().nullish(),
   mobilePhone: z.string().nullish(),
-  officeLocation: z.boolean().nullish(),
+  officeLocation: z.string().nullish(),
   preferredLanguage: z.string().nullish(),
   businessPhones: z.array(z.string()).nullish(),
 });


### PR DESCRIPTION
## Summary
This PR should fix this error:
`Error: [\n  {\n    \"code\": \"invalid_type\",\n    \"expected\": \"boolean\",\n    \"received\": \"string\",\n    \"path\": [\n      \"officeLocation\"\n    ],\n    \"message\": \"Expected boolean, received string\"\n  }\n]`

Because due to this document officeLocation must be a string not a boolean.
https://learn.microsoft.com/en-us/azure/active-directory-b2c/user-profile-attributes

## Testing
N/A

