### PR TITLE
refactor: tweak configuration template of the SMTP connector

### DIFF
--- a/packages/connector-smtp/docs/config-template.json
+++ b/packages/connector-smtp/docs/config-template.json
@@ -1,9 +1,9 @@
 {
   "host": "<test.smtp.host>",
-  "port": 80,
+  "port": 25,
   "auth": {
-    "pass": "<password>",
-    "user": "<username>"
+    "user": "<username>",
+    "pass": "<password>"
   },
   "fromEmail": "<notice@test.smtp>",
   "templates": [


### PR DESCRIPTION
## Summary

This PR updates the default port of the SMTP server to `25` (which is more common that `80`). It also inverts the order of the `pass` and `user` fields, by putting `user` first, as it's more common to first have the username and then the password (not the other way around).

## Testing

N/A

