### PR TITLE
feat: allow {{code}} to appear in email subject for smtp

### DIFF
--- a/packages/connector-smtp/src/index.ts
+++ b/packages/connector-smtp/src/index.ts
@@ -40,7 +40,7 @@ const sendMessage =
 
     const contentsObject = parseContents(
       typeof payload.code === 'string'
-        ? template.content.replace(/{{code}}/g, payload.code)
+        ? template.content.replace(/{{\s*code\s*}}/g, payload.code)
         : template.content,
       template.contentType
     );
@@ -49,7 +49,7 @@ const sendMessage =
       to,
       from: config.fromEmail,
       replyTo: config.replyTo,
-      subject: template.subject,
+      subject: template.subject.replace(/{{\s*code\s*}}/g, payload.code),
       ...contentsObject,
     };
 

--- a/packages/connector-smtp/src/mock.ts
+++ b/packages/connector-smtp/src/mock.ts
@@ -6,14 +6,14 @@ export const mockedConfig = {
   templates: [
     {
       contentType: 'text/plain',
-      content: 'This is for testing purposes only. Your verification code is {{code}}.',
+      content: 'This is for testing purposes only. Your verification code is {{    code }}.',
       subject: 'Logto Test with SMTP',
       usageType: 'Test',
     },
     {
       contentType: 'text/plain',
-      content: 'This is for sign-in purposes only. Your verification code is {{code}}.',
-      subject: 'Logto Sign-In with SMTP',
+      content: 'This is for sign-in purposes only. Your verification code is {{ code  }}.',
+      subject: 'Logto Sign-In with SMTP {{   code   }}',
       usageType: 'SignIn',
     },
     {


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Support the use of \{\{code}} in the email template's `subject` section

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Modify template to include {{code}} in the subject and see if it shows up.
