### PR TITLE
feat: make oauth connector token endpoint response type configurable

### DIFF
--- a/packages/connector-oauth2/src/index.ts
+++ b/packages/connector-oauth2/src/index.ts
@@ -59,7 +59,7 @@ const getAccessToken = async (config: OauthConfig, data: unknown, redirectUri: s
     return getAuthorizationCodeFlowAccessToken(config, data, redirectUri);
   }
 
-  return getImplicitFlowAccessToken(config, data);
+  return getImplicitFlowAccessToken(data);
 };
 
 const getUserInfo =

--- a/packages/connector-oauth2/src/types.ts
+++ b/packages/connector-oauth2/src/types.ts
@@ -37,11 +37,17 @@ export const userProfileGuard = z.object({
 
 export type UserProfile = z.infer<typeof userProfileGuard>;
 
+const tokenEndpointResponseTypeGuard = z
+  .enum(['query-string', 'json'])
+  .optional()
+  .default('query-string');
+
 export const authorizationCodeConfigGuard = z
   .object({
     oauthGrantType: z.literal(OauthGrantType.AuthorizationCode),
     responseType: z.literal('code').optional().default('code'),
     grantType: z.literal('authorization_code').optional().default('authorization_code'),
+    tokenEndpointResponseType: tokenEndpointResponseTypeGuard,
     authorizationEndpoint: z.string(),
     tokenEndpoint: z.string(),
     userInfoEndpoint: z.string(),
@@ -51,6 +57,8 @@ export const authorizationCodeConfigGuard = z
     profileMap: profileMapGuard,
   })
   .catchall(z.string());
+
+export type TokenEndpointResponseType = z.input<typeof tokenEndpointResponseTypeGuard>;
 
 export type AuthorizationCodeConfig = z.infer<typeof authorizationCodeConfigGuard>;
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Make oauth connector token endpoint response type configurable.

some social provider return token response as a query string and some return token response as a JSON.
We make the option configurable to choose the proper way to parse token endpoint response.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested locally.
