### PR TITLE
feat: support generic verification code type in email and sms connectors

### DIFF
--- a/.changeset/rich-fans-sip.md
+++ b/.changeset/rich-fans-sip.md
@@ -1,0 +1,15 @@
+---
+"@logto/connector-mock-standard-email": minor
+"@logto/connector-sendgrid-email": minor
+"@logto/connector-tencent-sms": minor
+"@logto/connector-aliyun-sms": minor
+"@logto/connector-mock-email": minor
+"@logto/connector-twilio-sms": minor
+"@logto/connector-aliyun-dm": minor
+"@logto/connector-mock-sms": minor
+"@logto/connector-aws-ses": minor
+"@logto/connector-smtp": minor
+---
+
+- Add "Generic" verification code type, remove deprecated "Continue" code type. Generic type verification code is used when user needs to send and verify verification code through our management APIs. Correspondingly, a "Generic" type mail or SMS template should be configured in the connector config.
+- Replace the term "passcode" with "verification code".

--- a/packages/connector-aliyun-dm/README.md
+++ b/packages/connector-aliyun-dm/README.md
@@ -25,7 +25,7 @@ The official Logto connector for Aliyun connector for direct mail service.
 
 ## Get started
 
-Aliyun is a primary cloud service provider in Asia, offering many cloud services, including DM (direct mail). Aliyun DM Connector is a plugin provided by the Logto team to call the Aliyun DM service APIs, with the help of which Logto end-users can register and sign in to their Logto account via mail verification code (or in other words, passcode).
+Aliyun is a primary cloud service provider in Asia, offering many cloud services, including DM (direct mail). Aliyun DM Connector is a plugin provided by the Logto team to call the Aliyun DM service APIs, with the help of which Logto end-users can register and sign in to their Logto account via mail verification code (or in other words, verification code).
 
 ## Set up an email service in Aliyun DirectMail Console
 
@@ -58,8 +58,8 @@ After finishing setup, there are two different ways to test:
     - Fill out the `accountName` and `fromAlias` field with "Sender Address" and "Email Tag" which were found in step 2. All templates will share this signature name. (You can leave `fromAlias` blank as it is OPTIONAL.)
     - You can add multiple DM connector templates for different cases. Here is an example of adding a single template:
         - Fill out the `subject` field, which will work as title of the sending email.
-        - Fill out the `content` field with arbitrary string-type contents. Do not forget to leave `{{code}}` placeholder for random passcode.
-        - Fill out `usageType` field with either `Register`, `SignIn`, `ForgotPassword` or `Test` for different use cases. (`usageType` is a Logto property to identify the proper use case.) In order to enable full user flows, templates with usageType `Register`, `SignIn` and `ForgotPassword` are required.
+        - Fill out the `content` field with arbitrary string-type contents. Do not forget to leave `{{code}}` placeholder for random verification code.
+        - Fill out `usageType` field with either `Register`, `SignIn`, `ForgotPassword`, `Generic` or `Test` for different use cases. (`usageType` is a Logto property to identify the proper use case.) In order to enable full user flows, templates with usageType `Register`, `SignIn` and `ForgotPassword` are required.
 
 Here is an example of Aliyun DM connector config JSON.
 
@@ -72,22 +72,27 @@ Here is an example of Aliyun DM connector config JSON.
     "templates": [
         {
             "subject": "<register-template-subject>",
-            "content": "<Logto: Your passcode is {{code}}. (regitser template)>",
+            "content": "<Logto: Your verification code is {{code}}. (register template)>",
             "usageType": "Register"
         },
         {
             "subject": "<sign-in-template-subject>",
-            "content": "<Logto: Your passcode is {{code}}. (sign-in template)>",
+            "content": "<Logto: Your verification code is {{code}}. (sign-in template)>",
             "usageType": "SignIn"
         },
         {
             "subject": "<forgot-password-template-subject>",
-            "content": "<Logto: Your passcode is {{code}}. (forgot-password template)>",
+            "content": "<Logto: Your verification code is {{code}}. (forgot-password template)>",
             "usageType": "ForgotPassword"
         },
         {
+            "subject": "<generic-template-subject>",
+            "content": "<Logto: Your verification code is {{code}}. (generic template)>",
+            "usageType": "Generic"
+        },
+        {
             "subject": "<test-template-subject>",
-            "content": "<Logto: Your passcode is {{code}}. (test template)>",
+            "content": "<Logto: Your verification code is {{code}}. (test template)>",
             "usageType": "Test"
         }
     ]
@@ -114,7 +119,7 @@ That's it. Don't forget to [Enable connector in sign-in experience](https://docs
 |---------------------|-------------|------------------------------------------------------|
 | subject             | string      | N/A                                                  |
 | content             | string      | N/A                                                  |
-| usageType           | enum string | 'Register' \| 'SignIn' \| 'ForgotPassword' \| 'Test' |
+| usageType           | enum string | 'Register' \| 'SignIn' \| 'ForgotPassword' \| 'Generic' \| 'Test' |
 
 # 阿里云邮件连接器
 
@@ -156,7 +161,7 @@ That's it. Don't forget to [Enable connector in sign-in experience](https://docs
     - 你可以添加多个邮件服务模板以应对不同的用户场景。这里展示填写单个模板的例子：
       - 在 `subject` 栏填写发送邮件的 _标题_。
       - 在 `content` 栏中填写字符形式的内容。不要忘了在内容中插入 `{{code}}` 占位符，在真实发送时他会被替换成随机生成的验证码。
-      - `usageType` 栏填写 `Register`，`SignIn`，`ForgotPassword` 或者 `Test` 其中之一以分别对应 _注册_，_登录_，_忘记密码_，_用户档案补全_ 和 _测试_ 的不同场景。（`usageType` 是 Logto 的属性，用来确定使用场景。）为了能够使用完成的流程，需要配置 `usageType` 为 `Register`，`SignIn` 以及 `ForgotPassword` 的模板。
+      - `usageType` 栏填写 `Register`，`SignIn`，`ForgotPassword`，`Generic` 或者 `Test` 其中之一以分别对应 _注册_，_登录_，_忘记密码_，_用户档案补全_ 和 _测试_ 的不同场景。（`usageType` 是 Logto 的属性，用来确定使用场景。）为了能够使用完成的流程，需要配置 `usageType` 为 `Register`，`SignIn` 以及 `ForgotPassword` 的模板。
 
 这是一个阿里云邮件服务连接器 JSON 配置的样例。
 
@@ -169,22 +174,27 @@ That's it. Don't forget to [Enable connector in sign-in experience](https://docs
     "templates": [
         {
             "subject": "<register-template-subject>",
-            "content": "<Logto: Your passcode is {{code}}. (regitser template)>",
+            "content": "<Logto: Your verification code is {{code}}. (register template)>",
             "usageType": "Register"
         },
         {
             "subject": "<sign-in-template-subject>",
-            "content": "<Logto: Your passcode is {{code}}. (sign-in template)>",
+            "content": "<Logto: Your verification code is {{code}}. (sign-in template)>",
             "usageType": "SignIn"
         },
         {
             "subject": "<forgot-password-template-subject>",
-            "content": "<Logto: Your passcode is {{code}}. (forgot-password template)>",
+            "content": "<Logto: Your verification code is {{code}}. (forgot-password template)>",
             "usageType": "ForgotPassword"
         },
         {
+            "subject": "<generic-template-subject>",
+            "content": "<Logto: Your verification code is {{code}}. (generic template)>",
+            "usageType": "Generic"
+        },
+        {
             "subject": "<test-template-subject>",
-            "content": "<Logto: Your passcode is {{code}}. (test template)>",
+            "content": "<Logto: Your verification code is {{code}}. (test template)>",
             "usageType": "Test"
         }
     ]
@@ -211,4 +221,4 @@ That's it. Don't forget to [Enable connector in sign-in experience](https://docs
 |-----------|-------------|------------------------------------------------------|
 | subject   | string      | N/A                                                  |
 | content   | string      | N/A                                                  |
-| usageType | enum string | 'Register' \| 'SignIn' \| 'ForgotPassword' \| 'Test' |
+| usageType | enum string | 'Register' \| 'SignIn' \| 'ForgotPassword' \| 'Generic' \| 'Test' |

--- a/packages/connector-aliyun-dm/docs/config-template.json
+++ b/packages/connector-aliyun-dm/docs/config-template.json
@@ -20,9 +20,9 @@
       "content": "<forgot-password-template-content>"
     },
     {
-      "usageType": "Continue",
-      "subject": "<continue-template-subject>",
-      "content": "<continue-template-content>"
+      "usageType": "Generic",
+      "subject": "<generic-template-subject>",
+      "content": "<generic-template-content>"
     },
     {
       "usageType": "Test",

--- a/packages/connector-aliyun-dm/src/types.ts
+++ b/packages/connector-aliyun-dm/src/types.ts
@@ -9,7 +9,7 @@ export type SendEmailResponse = z.infer<typeof sendEmailResponseGuard>;
 
 /**
  * UsageType here is used to specify the use case of the template, can be either
- * 'Register', 'SignIn', 'ForgotPassword' or 'Test'.
+ * 'Register', 'SignIn', 'ForgotPassword', 'Generic' or 'Test'.
  */
 const requiredTemplateUsageTypes = ['Register', 'SignIn', 'ForgotPassword'];
 

--- a/packages/connector-aliyun-sms/README.md
+++ b/packages/connector-aliyun-sms/README.md
@@ -26,7 +26,7 @@ The official Logto connector for Aliyun short message service.
 
 ## Get started
 
-Aliyun is a primary cloud service provider in Asia, offering many cloud services, including SMS (short message service). Aliyun SMS Connector is a plugin provided by the Logto team to call the Aliyun SMS service, with the help of which Logto end-users can register and sign in to their Logto account via SMS verification code (or in other words, passcode).
+Aliyun is a primary cloud service provider in Asia, offering many cloud services, including SMS (short message service). Aliyun SMS Connector is a plugin provided by the Logto team to call the Aliyun SMS service, with the help of which Logto end-users can register and sign in to their Logto account via SMS verification code.
 
 ## Set up a short message service in Aliyun SMS Console
 
@@ -45,8 +45,8 @@ Go to the [Aliyun website](https://cn.aliyun.com/) and register your Aliyun acco
 3. Read and agree to the "SMS service activation Agreement" (短信服务开通条款) and click "Subscribe to a service" (开通服务) to move on.
 4. You are now on the [SMS service console page](https://dysms.console.aliyun.com/overview), go to either "Mainland China" (国内消息) or "Outside Mainland China" (国际/港澳台消息) button on the sidebar per your use case.
 5. Add signature and template following the guidelines, and provide the materials or information required for review.
-    - Remember to select "Verification Code Message" (验证码) as "Scenario" (适用场景) when filling out the signature application and also "Verification Code Message" (验证码) for "Type" (模板类型) when applying for a template review because we are using these signatures and templates to send passcode. Currently, we do not support sending SMS messages other than verification-code-related text messages.
-    - Also, use `{{code}}` as a placeholder where you want to place your digital passcode in template contents.
+    - Remember to select "Verification Code Message" (验证码) as "Scenario" (适用场景) when filling out the signature application and also "Verification Code Message" (验证码) for "Type" (模板类型) when applying for a template review because we are using these signatures and templates to send verification code. Currently, we do not support sending SMS messages other than verification-code-related text messages.
+    - Also, use `{{code}}` as a placeholder where you want to place your digital verification code in template contents.
 6. After submitting your SMS signature and template application, you need to wait for it to take effect. At this point, we can go back to the [SMS service console page](https://dysms.console.aliyun.com/overview) and send a test SMS. If your signatures and templates are ready for use, you can try them directly; if they are not taking effect yet, Aliyun also provides test templates.
     - You may need to recharge a small amount of money before sending test messages.
     - You may also be asked to bind a test phone number before sending test messages. For more details, go to "Quick Start" (快速学习) tab from the sidebar of the [SMS service console page](https://dysms.console.aliyun.com/overview).
@@ -61,7 +61,7 @@ Go to the [Aliyun website](https://cn.aliyun.com/) and register your Aliyun acco
     - Fill out the `signName` field with "Signature" (签名名称) which is mentioned in step 2. All templates will share this signature name.
     - You can add multiple SMS connector templates for different cases. Here is an example of adding a single template:
         - Fill the `templateCode` field, which is how you can control SMS context, with "Template Code" (模板 CODE) from step 2.
-        - Fill out `usageType` field with either `Register`, `SignIn`, `ForgotPassword` or `Test` for different use cases. (`usageType` is a Logto property to identify the proper use case.) In order to enable full user flows, templates with usageType `Register`, `SignIn` and `ForgotPassword` are required.
+        - Fill out `usageType` field with either `Register`, `SignIn`, `ForgotPassword`, `Generic` or `Test` for different use cases. (`usageType` is a Logto property to identify the proper use case.) In order to enable full user flows, templates with usageType `Register`, `SignIn` and `ForgotPassword` are required.
 
 Here is an example of Aliyun SMS connector config JSON.
 
@@ -82,6 +82,10 @@ Here is an example of Aliyun SMS connector config JSON.
         {
             "templateCode": "<SMS_345678>",
             "usageType": "ForgotPassword"
+        },
+        {
+            "templateCode": "<SMS_456789>",
+            "usageType": "Generic"
         },
         {
             "templateCode": "<SMS_567890>",
@@ -109,7 +113,7 @@ That's it. Don't forget to [Enable connector in sign-in experience](https://docs
 | Template Properties | Type        | Enum values                                          |
 |---------------------|-------------|------------------------------------------------------|
 | templateCode        | string      | N/A                                                  |
-| usageType           | enum string | 'Register' \| 'SignIn' \| 'ForgotPassword' \| 'Test' |
+| usageType           | enum string | 'Register' \| 'SignIn' \| 'ForgotPassword' \| 'Generic' \| 'Test' |
 
 
 ## References
@@ -155,7 +159,7 @@ That's it. Don't forget to [Enable connector in sign-in experience](https://docs
     - 用你在步骤 2 中拿到的「签名名称」填入 `signName` 栏。所有的模板都会共用这个签名。
     - 你可以添加多个短信服务模板以应对不同的用户场景。这里展示填写单个模板的例子：
       - `templateCode` 栏是你可以用来控制所发送短信内容的属性。它们的值从步骤 2 中的「模板 CODE」获取。
-      - `usageType` 栏填写 `Register`，`SignIn`，`ForgotPassword` 或者 `Test` 其中之一以分别对应 _注册_，_登录_，_忘记密码_，_用户档案补全_ 和 _测试_ 的不同场景。（`usageType` 是 Logto 的属性，用来确定使用场景。）为了能够使用完成的流程，需要配置 `usageType` 为 `Register`，`SignIn` 以及 `ForgotPassword` 的模板。
+      - `usageType` 栏填写 `Register`，`SignIn`，`ForgotPassword`，`Generic` 或者 `Test` 其中之一以分别对应 _注册_，_登录_，_忘记密码_，_用户档案补全_ 和 _测试_ 的不同场景。（`usageType` 是 Logto 的属性，用来确定使用场景。）为了能够使用完成的流程，需要配置 `usageType` 为 `Register`，`SignIn` 以及 `ForgotPassword` 的模板。
 
 这是一个阿里云短信服务连接器 JSON 配置的样例。
 
@@ -176,6 +180,10 @@ That's it. Don't forget to [Enable connector in sign-in experience](https://docs
         {
             "templateCode": "<SMS_345678>",
             "usageType": "ForgotPassword"
+        },
+        {
+            "templateCode": "<SMS_456789>",
+            "usageType": "Generic"
         },
         {
             "templateCode": "<SMS_567890>",
@@ -203,7 +211,7 @@ That's it. Don't forget to [Enable connector in sign-in experience](https://docs
 | 模板属性      | 类型         | 枚举值                                                |
 |--------------|-------------|------------------------------------------------------|
 | templateCode | string      | N/A                                                  |
-| usageType    | enum string | 'Register' \| 'SignIn' \| 'ForgotPassword' \| 'Test' |
+| usageType    | enum string | 'Register' \| 'SignIn' \| 'ForgotPassword' \| 'Generic' \| 'Test' |
 
 
 ## 参考

--- a/packages/connector-aliyun-sms/docs/config-template.json
+++ b/packages/connector-aliyun-sms/docs/config-template.json
@@ -16,7 +16,7 @@
       "templateCode": "<template-code>"
     },
     {
-      "usageType": "Continue",
+      "usageType": "Generic",
       "templateCode": "<template-code>"
     },
     {

--- a/packages/connector-aliyun-sms/src/constant.ts
+++ b/packages/connector-aliyun-sms/src/constant.ts
@@ -14,13 +14,13 @@ export const staticConfigs = {
  * Details of SmsTemplateType can be found at:
  * https://next.api.aliyun.com/document/Dysmsapi/2017-05-25/QuerySmsTemplateList.
  *
- * For our use case is to send passcode sms for passwordless sign-in/up as well as
- * reset password, the default value of type code is set to be 2.
+ * In our use case, it is to send verification code SMS for passwordless sign-in/up as well as
+ * reset password. The default value of type code is set to 2.
  */
 export enum SmsTemplateType {
   Notification = 0,
   Promotion = 1,
-  Passcode = 2,
+  VerificationCode = 2,
   InternationalMessage = 6,
   PureNumber = 7,
 }

--- a/packages/connector-aliyun-sms/src/types.ts
+++ b/packages/connector-aliyun-sms/src/types.ts
@@ -37,11 +37,11 @@ export type PublicParameters = {
 
 /**
  * UsageType here is used to specify the use case of the template, can be either
- * 'Register', 'SignIn', 'ForgotPassword' or 'Test'.
+ * 'Register', 'SignIn', 'ForgotPassword', 'Generic' or 'Test'.
  *
- * Type here in the template is used to specify the purpose of sending the sms,
+ * Type here in the template is used to specify the purpose of sending the SMS,
  * can be either item in SmsTemplateType.
- * As the SMS is applied for sending passcode, the value should always be 2 in our case.
+ * As the SMS is applied for sending verification code, the value should always be 2 in our case.
  */
 const requiredTemplateUsageTypes = ['Register', 'SignIn', 'ForgotPassword'];
 

--- a/packages/connector-aws-ses/README.md
+++ b/packages/connector-aws-ses/README.md
@@ -24,7 +24,7 @@ Amazon SES邮件推送服务 Logto 官方连接器[中文文档](#aws-ses邮件�
 ## Get started
 Amazon SES is a cloud email service provider that can integrate into any application for bulk email sending.
 
-Logto team to call the Amazon Simple Email Service APIs, with the help of which Logto end-users can register and sign in to their Logto account via mail verification code (or in other words, passcode).
+Logto team to call the Amazon Simple Email Service APIs, with the help of which Logto end-users can register and sign in to their Logto account via mail verification code.
 
 
 ## Configure a mail service in the AWS service console
@@ -84,6 +84,11 @@ Here is an example of the JSON of the `Amazon SES` connector:
       "content": "<forgot-password-template-content>"
     },
     {
+      "usageType": "Generic",
+      "subject": "<generic-template-subject>",
+      "content": "<generic-template-content>"
+    },
+    {
       "usageType": "Test",
       "subject": "<test-template-subject>",
       "content": "<test-template-content>"
@@ -117,7 +122,7 @@ That's it. Don't forget to [Enable connector in sign-in experience](https://docs
 | ------------------- | ----------- | -----------------------------------------------------|
 | subject             | string      | N/A                                                  |
 | content             | string      | N/A                                                  |
-| usageType           | enum string | 'Register' \| 'SignIn' \| 'ForgotPassword' \| 'Test' |
+| usageType           | enum string | 'Register' \| 'SignIn' \| 'ForgotPassword' \| 'Generic' \| 'Test' |
 
 
 # AWS SES 邮件连接器
@@ -183,6 +188,11 @@ Amazon SES 是云电子邮件发送服务，它可以集成到任何应用程序
       "content": "<forgot-password-template-content>"
     },
     {
+      "usageType": "Generic",
+      "subject": "<generic-template-subject>",
+      "content": "<generic-template-content>"
+    },
+    {
       "usageType": "Test",
       "subject": "<test-template-subject>",
       "content": "<test-template-content>"
@@ -216,4 +226,4 @@ Amazon SES 是云电子邮件发送服务，它可以集成到任何应用程序
 | --------- | ----------- | -----------------------------------------------------|
 | subject   | string      | N/A                                                  |
 | content   | string      | N/A                                                  |
-| usageType | enum string | 'Register' \| 'SignIn' \| 'ForgotPassword' \| 'Test' |
+| usageType | enum string | 'Register' \| 'SignIn' \| 'ForgotPassword' \| 'Generic' \| 'Test' |

--- a/packages/connector-aws-ses/docs/config-template.json
+++ b/packages/connector-aws-ses/docs/config-template.json
@@ -24,6 +24,11 @@
       "content": "<forgot-password-template-content>"
     },
     {
+      "usageType": "Generic",
+      "subject": "<generic-template-subject>",
+      "content": "<generic-template-content>"
+    },
+    {
       "usageType": "Test",
       "subject": "<test-template-subject>",
       "content": "<test-template-content>"

--- a/packages/connector-aws-ses/src/index.test.ts
+++ b/packages/connector-aws-ses/src/index.test.ts
@@ -59,7 +59,7 @@ describe('sendMessage()', () => {
     await expect(
       connector.sendMessage({
         to: 'to@email.com',
-        type: VerificationCodeType.Register,
+        type: VerificationCodeType.Test,
         payload: { code: '1234' },
       })
     ).rejects.toThrow();

--- a/packages/connector-aws-ses/src/mock.ts
+++ b/packages/connector-aws-ses/src/mock.ts
@@ -9,5 +9,15 @@ export const mockedConfig = {
       content: 'Your code is {{code}}, {{code}} is your code',
       subject: 'subject',
     },
+    {
+      usageType: 'Register',
+      content: 'Your code is {{code}}, {{code}} is your code',
+      subject: 'subject',
+    },
+    {
+      usageType: 'ForgotPassword',
+      content: 'Your code is {{code}}, {{code}} is your code',
+      subject: 'subject',
+    },
   ],
 };

--- a/packages/connector-aws-ses/src/types.ts
+++ b/packages/connector-aws-ses/src/types.ts
@@ -2,8 +2,9 @@ import { z } from 'zod';
 
 /**
  * UsageType here is used to specify the use case of the template, can be either
- * 'Register', 'SignIn', 'ForgotPassword' or 'Test'.
+ * 'Register', 'SignIn', 'ForgotPassword', 'Generic' or 'Test'.
  */
+const requiredTemplateUsageTypes = ['Register', 'SignIn', 'ForgotPassword'];
 const templateGuard = z.object({
   usageType: z.string(),
   subject: z.string(),
@@ -18,7 +19,19 @@ export const awsSesConfigGuard = z.object({
   region: z.string(),
   emailAddress: z.string().optional(),
   emailAddressIdentityArn: z.string().optional(),
-  templates: z.array(templateGuard),
+  templates: z.array(templateGuard).refine(
+    (templates) =>
+      requiredTemplateUsageTypes.every((requiredType) =>
+        templates.map((template) => template.usageType).includes(requiredType)
+      ),
+    (templates) => ({
+      message: `Template with UsageType (${requiredTemplateUsageTypes
+        .filter(
+          (requiredType) => !templates.map((template) => template.usageType).includes(requiredType)
+        )
+        .join(', ')}) should be provided!`,
+    })
+  ),
   feedbackForwardingEmailAddress: z.string().optional(),
   feedbackForwardingEmailAddressIdentityArn: z.string().optional(),
   configurationSetName: z.string().optional(),

--- a/packages/connector-mock-email-alternative/docs/config-template.json
+++ b/packages/connector-mock-email-alternative/docs/config-template.json
@@ -7,25 +7,31 @@
       "usageType": "SignIn",
       "type": "text/plain",
       "subject": "Logto SignIn Template",
-      "content": "This is for sign-in purposes only. Your passcode is {{code}}."
+      "content": "This is for sign-in purposes only. Your verification code is {{code}}."
     },
     {
       "usageType": "Register",
       "type": "text/plain",
       "subject": "Logto Register Template",
-      "content": "This is for registering purposes only. Your passcode is {{code}}."
+      "content": "This is for registering purposes only. Your verification code is {{code}}."
+    },
+    {
+      "usageType": "Generic",
+      "type": "text/plain",
+      "subject": "Logto Generic Template",
+      "content": "This is for generic purpose through management API only. Your verification code is {{code}}."
     },
     {
       "usageType": "Test",
       "type": "text/plain",
       "subject": "Logto Test Template",
-      "content": "This is for testing purposes only. Your passcode is {{code}}."
+      "content": "This is for testing purposes only. Your verification code is {{code}}."
     },
     {
       "usageType": "ForgotPassword",
       "type": "text/plain",
       "subject": "Logto Forgot Password Template",
-      "content": "This is for forgot-password purposes only. Your passcode is {{code}}."
+      "content": "This is for forgot-password purposes only. Your verification code is {{code}}."
     }
   ]
 }

--- a/packages/connector-mock-email-alternative/src/index.ts
+++ b/packages/connector-mock-email-alternative/src/index.ts
@@ -37,7 +37,7 @@ const sendMessage =
     );
 
     await fs.writeFile(
-      path.join('/tmp', 'logto_mock_passcode_record.txt'),
+      path.join('/tmp', 'logto_mock_verification_code_record.txt'),
       JSON.stringify({ address: to, code: payload.code, type }) + '\n'
     );
 

--- a/packages/connector-mock-email/docs/config-template.json
+++ b/packages/connector-mock-email/docs/config-template.json
@@ -7,31 +7,31 @@
       "usageType": "SignIn",
       "type": "text/plain",
       "subject": "Logto SignIn Template",
-      "content": "This is for sign-in purposes only. Your passcode is {{code}}."
+      "content": "This is for sign-in purposes only. Your verification code is {{code}}."
     },
     {
       "usageType": "Register",
       "type": "text/plain",
       "subject": "Logto Register Template",
-      "content": "This is for registering purposes only. Your passcode is {{code}}."
+      "content": "This is for registering purposes only. Your verification code is {{code}}."
     },
     {
       "usageType": "ForgotPassword",
       "type": "text/plain",
       "subject": "Logto ForgotPassword Template",
-      "content": "This is for resetting password purposes only. Your passcode is {{code}}."
+      "content": "This is for resetting password purposes only. Your verification code is {{code}}."
+    },
+    {
+      "usageType": "Generic",
+      "type": "text/plain",
+      "subject": "Logto Generic Template",
+      "content": "This is for generic purpose through management API only. Your verification code is {{code}}."
     },
     {
       "usageType": "Test",
       "type": "text/plain",
       "subject": "Logto Test Template",
-      "content": "This is for testing purposes only. Your passcode is {{code}}."
-    },
-    {
-      "usageType": "ForgotPassword",
-      "type": "text/plain",
-      "subject": "Logto Forgot Password Template",
-      "content": "This is for forgot-password purposes only. Your passcode is {{code}}."
+      "content": "This is for testing purposes only. Your verification code is {{code}}."
     }
   ]
 }

--- a/packages/connector-mock-email/src/index.ts
+++ b/packages/connector-mock-email/src/index.ts
@@ -37,7 +37,7 @@ const sendMessage =
     );
 
     await fs.writeFile(
-      path.join('/tmp', 'logto_mock_passcode_record.txt'),
+      path.join('/tmp', 'logto_mock_verification_code_record.txt'),
       JSON.stringify({ address: to, code: payload.code, type }) + '\n'
     );
 

--- a/packages/connector-mock-sms/docs/config-template.json
+++ b/packages/connector-mock-sms/docs/config-template.json
@@ -5,23 +5,23 @@
   "templates": [
     {
       "usageType": "SignIn",
-      "content": "This is for sign-in purposes only. Your passcode is {{code}}."
+      "content": "This is for sign-in purposes only. Your verification code is {{code}}."
     },
     {
       "usageType": "Register",
-      "content": "This is for registering purposes only. Your passcode is {{code}}."
+      "content": "This is for registering purposes only. Your verification code is {{code}}."
     },
     {
       "usageType": "ForgotPassword",
-      "content": "This is for resetting password purposes only. Your passcode is {{code}}."
+      "content": "This is for resetting password purposes only. Your verification code is {{code}}."
+    },
+    {
+      "usageType": "Generic",
+      "content": "This is for generic purpose through management API only. Your verification code is {{code}}."
     },
     {
       "usageType": "Test",
-      "content": "This is for testing purposes only. Your passcode is {{code}}."
-    },
-    {
-      "usageType": "ForgotPassword",
-      "content": "This is for forgot-password purposes only. Your passcode is {{code}}."
+      "content": "This is for testing purposes only. Your verification code is {{code}}."
     }
   ]
 }

--- a/packages/connector-mock-sms/src/index.ts
+++ b/packages/connector-mock-sms/src/index.ts
@@ -37,7 +37,7 @@ const sendMessage =
     );
 
     await fs.writeFile(
-      path.join('/tmp', 'logto_mock_passcode_record.txt'),
+      path.join('/tmp', 'logto_mock_verification_code_record.txt'),
       JSON.stringify({ phone: to, code: payload.code, type }) + '\n'
     );
 

--- a/packages/connector-sendgrid-email/README.md
+++ b/packages/connector-sendgrid-email/README.md
@@ -62,8 +62,8 @@ Fill out the `fromEmail` and `fromName` fields with the senders' _From Address_ 
 You can add multiple SendGrid mail connector templates for different cases. Here is an example of adding a single template:
 
 - Fill out the `subject` field, which works as the title of emails.
-- Fill out the `content` field with arbitrary string-typed contents. Do not forget to leave the `{{code}}` placeholder for the random passcode.
-- Fill out `usageType` field with either `Register`, `SignIn`, `ForgotPassword` or `Test` for different use cases.
+- Fill out the `content` field with arbitrary string-typed contents. Do not forget to leave the `{{code}}` placeholder for the random verification code.
+- Fill out `usageType` field with either `Register`, `SignIn`, `ForgotPassword`, `Generic` or `Test` for different use cases.
 - Fill out `type` field with either `text/plain` or `text/html` for different types of content.
 
 In order to enable full user flows, templates with usageType `Register`, `SignIn` and `ForgotPassword` are required.
@@ -78,25 +78,31 @@ Here is an example of SendGrid connector config JSON.
     "templates": [
         {
             "subject": "<register-template-subject>",
-            "content": "<Logto: Your passcode is {{code}}. (regitser template)>",
+            "content": "<Logto: Your verification code is {{code}}. (register template)>",
             "usageType": "Register",
             "type": "text/plain"
         },
         {
             "subject": "<sign-in-template-subject>",
-            "content": "<Logto: Your passcode is {{code}}. (sign-in template)>",
+            "content": "<Logto: Your verification code is {{code}}. (sign-in template)>",
             "usageType": "SignIn",
             "type": "text/plain"
         },
         {
             "subject": "<forgot-password-template-subject>",
-            "content": "<Logto: Your passcode is {{code}}. (forgot-password template)>",
+            "content": "<Logto: Your verification code is {{code}}. (forgot-password template)>",
             "usageType": "ForgotPassword",
             "type": "text/plain"
         },
         {
+            "subject": "<generic-template-subject>",
+            "content": "<Logto: Your verification code is {{code}}. (generic template)>",
+            "usageType": "Generic",
+            "type": "text/plain",
+        },
+        {
             "subject": "<test-template-subject>",
-            "content": "<Logto: Your passcode is {{code}}. (test template)>",
+            "content": "<Logto: Your verification code is {{code}}. (test template)>",
             "usageType": "Test",
             "type": "text/plain"
         },
@@ -123,7 +129,7 @@ That's it. Don't forget to [Enable connector in sign-in experience](https://docs
 |---------------------|-------------|------------------------------------------------------|
 | subject             | string      | N/A                                                  |
 | content             | string      | N/A                                                  |
-| usageType           | enum string | 'Register' \| 'SignIn' \| 'ForgotPassword' \| 'Test' |
+| usageType           | enum string | 'Register' \| 'SignIn' \| 'ForgotPassword' \| 'Generic' \| 'Test' |
 | type                | enum string | 'text/plain' \| 'text/html'                          |
 
 # SendGrid 邮件连接器
@@ -168,7 +174,7 @@ _Domain Authentication_ 是推荐，但是不强制的。你可以点按 "Authen
 
 - 填写 `subject` 栏，它是发送邮件的标题
 - 用字符型的值填入 `content` 栏，不要忘了用占位符 `{{code}}` 预留你想放置随机生成的验证码的位置
-- 从 `Register`，`SignIn`，`ForgotPassword` 或者 `Test` 中选一个填入 `usageType` 栏，以决定当前模板所使用的场景
+- 从 `Register`，`SignIn`，`ForgotPassword`，`Generic` 或者 `Test` 中选一个填入 `usageType` 栏，以决定当前模板所使用的场景
 - 用 `text/plain` 或 `text/html` 填入 `type` 栏，以表明内容的形式
 
 为了能够使用完成的流程，需要配置 `usageType` 为 `Register`，`SignIn` 以及 `ForgotPassword` 的模板。
@@ -183,25 +189,31 @@ _Domain Authentication_ 是推荐，但是不强制的。你可以点按 "Authen
     "templates": [
         {
             "subject": "<register-template-subject>",
-            "content": "<Logto: Your passcode is {{code}}. (regitser template)>",
+            "content": "<Logto: Your verification code is {{code}}. (register template)>",
             "usageType": "Register",
             "type": "text/plain"
         },
         {
             "subject": "<sign-in-template-subject>",
-            "content": "<Logto: Your passcode is {{code}}. (sign-in template)>",
+            "content": "<Logto: Your verification code is {{code}}. (sign-in template)>",
             "usageType": "SignIn",
             "type": "text/plain"
         },
         {
             "subject": "<forgot-password-template-subject>",
-            "content": "<Logto: Your passcode is {{code}}. (forgot-password template)>",
+            "content": "<Logto: Your verification code is {{code}}. (forgot-password template)>",
             "usageType": "ForgotPassword",
             "type": "text/plain"
         },
         {
+            "subject": "<generic-template-subject>",
+            "content": "<Logto: Your verification code is {{code}}. (generic template)>",
+            "usageType": "Generic",
+            "type": "text/plain"
+        },
+        {
             "subject": "<test-template-subject>",
-            "content": "<Logto: Your passcode is {{code}}. (test template)>",
+            "content": "<Logto: Your verification code is {{code}}. (test template)>",
             "usageType": "Test",
             "type": "text/plain"
         },
@@ -228,5 +240,5 @@ _Domain Authentication_ 是推荐，但是不强制的。你可以点按 "Authen
 |-----------|-------------|------------------------------------------------------|
 | subject   | string      | N/A                                                  |
 | content   | string      | N/A                                                  |
-| usageType | enum string | 'Register' \| 'SignIn' \| 'ForgotPassword' \| 'Test' |
+| usageType | enum string | 'Register' \| 'SignIn' \| 'ForgotPassword' \| 'Generic' \| 'Test' |
 | type      | enum string | 'text/plain' \| 'text/html'                          |

--- a/packages/connector-sendgrid-email/docs/config-template.json
+++ b/packages/connector-sendgrid-email/docs/config-template.json
@@ -7,25 +7,31 @@
       "usageType": "SignIn",
       "type": "text/plain",
       "subject": "Logto SignIn Template",
-      "content": "This is for sign-in purposes only. Your passcode is {{code}}."
+      "content": "This is for sign-in purposes only. Your verification code is {{code}}."
     },
     {
       "usageType": "Register",
       "type": "text/plain",
       "subject": "Logto Register Template",
-      "content": "This is for registering purposes only. Your passcode is {{code}}."
+      "content": "This is for registering purposes only. Your verification code is {{code}}."
     },
     {
       "usageType": "ForgotPassword",
       "type": "text/plain",
       "subject": "Logto ForgotPassword Template",
-      "content": "This is for resetting password purposes only. Your passcode is {{code}}."
+      "content": "This is for resetting password purposes only. Your verification code is {{code}}."
+    },
+    {
+      "usageType": "Generic",
+      "type": "text/plain",
+      "subject": "Logto Generic Template",
+      "content": "This is for generic purpose through management API only. Your verification code is {{code}}."
     },
     {
       "usageType": "Test",
       "type": "text/plain",
       "subject": "Logto Test Template",
-      "content": "This is for testing purposes only. Your passcode is {{code}}."
+      "content": "This is for testing purposes only. Your verification code is {{code}}."
     }
   ]
 }

--- a/packages/connector-sendgrid-email/src/mock.ts
+++ b/packages/connector-sendgrid-email/src/mock.ts
@@ -29,7 +29,7 @@ export const mockedConfig: SendGridMailConfig = {
       usageType: 'Test',
       type: ContextType.Text,
       subject: 'Logto Test Template',
-      content: 'This is for testing purposes only. Your passcode is {{code}}.',
+      content: 'This is for testing purposes only. Your verification code is {{code}}.',
     },
   ],
 };

--- a/packages/connector-sendgrid-email/src/types.ts
+++ b/packages/connector-sendgrid-email/src/types.ts
@@ -72,7 +72,7 @@ export type PublicParameters = {
   personalizations: Personalization[];
   from: EmailData;
   reply_to?: EmailData;
-  reply_to_list?: EmailData[]; // Maxitems: 1000, uniqueItems: true
+  reply_to_list?: EmailData[]; // MaxItems: 1000, uniqueItems: true
   subject: string; // MinLength: 1
   content: Content[];
   attachments?: Attachment[];
@@ -90,7 +90,7 @@ export type PublicParameters = {
 
 /**
  * UsageType here is used to specify the use case of the template, can be either
- * 'Register', 'SignIn', 'ForgotPassword' or 'Test'.
+ * 'Register', 'SignIn', 'ForgotPassword', 'Generic' or 'Test'.
  */
 const requiredTemplateUsageTypes = ['Register', 'SignIn', 'ForgotPassword'];
 

--- a/packages/connector-smtp/README.md
+++ b/packages/connector-smtp/README.md
@@ -59,7 +59,7 @@ By following the post, your connector JSON should be like this:
     "templates": [
         {
             "subject": "<register-template-subject>",
-            "content": "<Logto: Your passcode is {{code}}. (regitser template)>",
+            "content": "<Logto: Your verification code is {{code}}. (register template)>",
             "usageType": "Register",
             "contentType": "text/plain"
         }
@@ -89,7 +89,7 @@ After going through the guide, your connector JSON should look like this:
     "templates": [
         {
             "subject": "<register-template-subject>",
-            "content": "<Logto: Your passcode is {{code}}. (regitser template)>",
+            "content": "<Logto: Your verification code is {{code}}. (register template)>",
             "usageType": "Register",
             "contentType": "text/plain"
         }
@@ -121,7 +121,7 @@ After going through the guide, your connector JSON should look like this:
     "templates": [
         {
             "subject": "<register-template-subject>",
-            "content": "<Logto: Your passcode is {{code}}. (regitser template)>",
+            "content": "<Logto: Your verification code is {{code}}. (register template)>",
             "usageType": "Register",
             "contentType": "text/plain"
         }
@@ -133,7 +133,7 @@ After going through the guide, your connector JSON should look like this:
 >
 > Only one sample template is provided in the previous cases to keep things simple. You should add more templates for other use cases.
 > You should change values wrapped with "<" and ">" according to your Gmail, SendGrid or Aliyun account settings and choose to keep other fields w/o "<" and ">".
-> Add `{{code}}` as a placeholder in templates' content to show random passcode in sending emails.
+> Add `{{code}}` as a placeholder in templates' content to show random verification code in sending emails.
 
 ### Test SMTP connector
 
@@ -154,7 +154,7 @@ That's it. Don't forget to [Enable connector in sign-in experience](https://docs
 |---------------------|-------------|------------------------------------------------------|
 | subject             | string      | N/A                                                  |
 | content             | string      | N/A                                                  |
-| usageType           | enum string | 'Register' \| 'SignIn' \| 'ForgotPassword' \| 'Test' |
+| usageType           | enum string | 'Register' \| 'SignIn' \| 'ForgotPassword' \| 'Generic' \| 'Test' |
 | contentType         | enum string | 'text/plain' \| 'text/html'                          |
 
 **Username and password Auth Options**
@@ -214,7 +214,7 @@ SMTP 是一个所有邮件服务提供商通用的传输协议。
     "templates": [
         {
             "subject": "<register-template-subject>",
-            "content": "<Logto: Your passcode is {{code}}. (regitser template)>",
+            "content": "<Logto: Your verification code is {{code}}. (register template)>",
             "usageType": "Register",
             "contentType": "text/plain"
         }
@@ -244,7 +244,7 @@ SMTP 是一个所有邮件服务提供商通用的传输协议。
     "templates": [
         {
             "subject": "<register-template-subject>",
-            "content": "<Logto: Your passcode is {{code}}. (regitser template)>",
+            "content": "<Logto: Your verification code is {{code}}. (register template)>",
             "usageType": "Register",
             "contentType": "text/plain"
         }
@@ -276,7 +276,7 @@ SMTP 是一个所有邮件服务提供商通用的传输协议。
     "templates": [
         {
             "subject": "<register-template-subject>",
-            "content": "<Logto: Your passcode is {{code}}. (regitser template)>",
+            "content": "<Logto: Your verification code is {{code}}. (register template)>",
             "usageType": "Register",
             "contentType": "text/plain"
         }
@@ -309,7 +309,7 @@ SMTP 是一个所有邮件服务提供商通用的传输协议。
 |-------------|-------------|------------------------------------------------------|
 | subject     | string      | N/A                                                  |
 | content     | string      | N/A                                                  |
-| usageType   | enum string | 'Register' \| 'SignIn' \| 'ForgotPassword' \| 'Test' |
+| usageType   | enum string | 'Register' \| 'SignIn' \| 'ForgotPassword' \| 'Generic' \| 'Test' |
 | contentType | enum string | 'text/plain' \| 'text/html'                          |
 
 **用户名密码的授权配置**

--- a/packages/connector-smtp/docs/config-template.json
+++ b/packages/connector-smtp/docs/config-template.json
@@ -30,6 +30,12 @@
           "content": "This is for forgot-password purposes only. Your verification code is {{code}}.",
           "subject": "Logto Forgot Password with SMTP",
           "usageType": "ForgotPassword"
+      },
+      {
+          "contentType": "text/plain",
+          "content": "This is for generic purpose through management API only. Your verification code is {{code}}.",
+          "subject": "Logto Generic with SMTP",
+          "usageType": "Generic"
       }
   ],
   "secure": true,

--- a/packages/connector-smtp/src/types.ts
+++ b/packages/connector-smtp/src/types.ts
@@ -7,7 +7,7 @@ import { z } from 'zod';
 
 /**
  * UsageType here is used to specify the use case of the template, can be either
- * 'Register', 'SignIn', 'ForgotPassword' or 'Test'.
+ * 'Register', 'SignIn', 'ForgotPassword', 'Generic' or 'Test'.
  */
 const requiredTemplateUsageTypes = ['Register', 'SignIn', 'ForgotPassword'];
 

--- a/packages/connector-tencent-sms/README.md
+++ b/packages/connector-tencent-sms/README.md
@@ -62,7 +62,7 @@ The official Logto connector for Tencent short message service.
     - 用你在步骤 2 中拿到的「签名名称」填入 `signName` 栏。所有的模板都会共用这个签名。
     - 你可以添加多个短信服务模板以应对不同的用户场景。这里展示填写单个模板的例子：
         - `templateCode` 栏是你可以用来控制所发送短信内容的属性。它们的值从步骤 2 中的「模板 CODE」获取。
-        - `usageType` 栏填写 `Register`，`SignIn`，`ForgotPassword` 或者 `Test` 其中之一以分别对应 _注册_，
+        - `usageType` 栏填写 `Register`，`SignIn`，`ForgotPassword`，`Generic` 或者 `Test` 其中之一以分别对应 _注册_，
           _登录_，_忘记密码_，_用户档案补全_ 和 _测试_ 的不同场景。（`usageType` 是 Logto 的属性，用来确定使用场景。）为了能够使用完成的流程，需要配置 `usageType` 为 `Register`，`SignIn` 以及 `ForgotPassword` 的模板。
     - 在 [应用管理](https://console.cloud.tencent.com/smsv2/app-manage) 获取应用 ID 填写入 `sdkAppId` 栏。
     - 在 [发送文档](https://cloud.tencent.com/document/api/382/52071#.E5.9C.B0.E5.9F.9F.E5.88.97.E8.A1.A8)
@@ -88,6 +88,10 @@ The official Logto connector for Tencent short message service.
     },
     {
       "usageType": "ForgotPassword",
+      "templateCode": "<template-code>"
+    },
+    {
+      "usageType": "Generic",
       "templateCode": "<template-code>"
     },
     {
@@ -119,7 +123,7 @@ The official Logto connector for Tencent short message service.
 | 模板属性      | 类型         | 枚举值                                                 |
 |--------------|-------------|-------------------------------------------------------|
 | templateCode | string      | N/A                                                   |
-| usageType    | enum string | 'Register' \ | 'SignIn' \| 'ForgotPassword' \| 'Test' |
+| usageType    | enum string | 'Register' \ | 'SignIn' \| 'ForgotPassword' \| 'Generic' \| 'Test' |
 
 ## 参考
 

--- a/packages/connector-tencent-sms/docs/config-template.json
+++ b/packages/connector-tencent-sms/docs/config-template.json
@@ -18,6 +18,10 @@
       "templateCode": "<template-code>"
     },
     {
+      "usageType": "Generic",
+      "templateCode": "<template-code>"
+    },
+    {
       "usageType": "Test",
       "templateCode": "<template-code>"
     }

--- a/packages/connector-tencent-sms/src/schema.ts
+++ b/packages/connector-tencent-sms/src/schema.ts
@@ -1,5 +1,9 @@
 import { z } from 'zod';
 
+/**
+ * UsageType here is used to specify the use case of the template, can be either
+ * 'Register', 'SignIn', 'ForgotPassword', 'Generic' or 'Test'.
+ */
 const requiredTemplateUsageTypes = ['Register', 'SignIn', 'ForgotPassword'];
 
 export const SingleSmsConfig = z.object({

--- a/packages/connector-twilio-sms/README.md
+++ b/packages/connector-twilio-sms/README.md
@@ -66,8 +66,8 @@ Fill out the _accountSID_, _authToken_ and _fromMessagingServiceSID_ fields with
 
 You can add multiple SMS connector templates for different cases. Here is an example of adding a single template:
 
-- Fill out the `content` field with arbitrary string-typed contents. Do not forget to leave `{{code}}` placeholder for random passcode.
-- Fill out the `usageType` field with either `Register`, `SignIn`, `ForgotPassword` or `Test` for different use cases. In order to enable full user flows, templates with usageType `Register`, `SignIn` and `ForgotPassword` are required.
+- Fill out the `content` field with arbitrary string-typed contents. Do not forget to leave `{{code}}` placeholder for random verification code.
+- Fill out the `usageType` field with either `Register`, `SignIn`, `ForgotPassword`, `Generic` or `Test` for different use cases. In order to enable full user flows, templates with usageType `Register`, `SignIn` and `ForgotPassword` are required.
 
 Here is an example of Twilio SMS connector config JSON.
 
@@ -78,19 +78,23 @@ Here is an example of Twilio SMS connector config JSON.
     "fromMessagingServiceSID": "<messaging-service-sid>",
     "templates": [
         {
-            "content": "<arbitrary-register-template-contents: your passcode is {{code}}>",
+            "content": "<arbitrary-register-template-contents: your verification code is {{code}}>",
             "usageType": "Register"
         },
         {
-            "content": "<arbitrary-sign-in-template-contents: your passcode is {{code}}>",
+            "content": "<arbitrary-sign-in-template-contents: your verification code is {{code}}>",
             "usageType": "SignIn"
         },
         {
-            "content": "<arbitrary-forgot-password-template-contents: your passcode is {{code}}>",
+            "content": "<arbitrary-forgot-password-template-contents: your verification code is {{code}}>",
             "usageType": "ForgotPassword"
         },
         {
-            "content": "<arbitrary-test-template-contents: your passcode is {{code}}>",
+            "content": "<arbitrary-generic-template-contents: your verification code is {{code}}>",
+            "usageType": "Generic"
+        },
+        {
+            "content": "<arbitrary-test-template-contents: your verification code is {{code}}>",
             "usageType": "Test"
         }
     ]
@@ -115,7 +119,7 @@ That's it. Don't forget to [Enable connector in sign-in experience](https://docs
 | Template Properties | Type        | Enum values                                          |
 |---------------------|-------------|------------------------------------------------------|
 | content             | string      | N/A                                                  |
-| usageType           | enum string | 'Register' \| 'SignIn' \| 'ForgotPassword' \| 'Test' |
+| usageType           | enum string | 'Register' \| 'SignIn' \| 'ForgotPassword' \| 'Generic' \| 'Test' |
 
 ## Reference
 
@@ -166,7 +170,7 @@ Twilio 提供可编程的通信工具，用于拨打和接听电话、发送和�
 你可以添加多个短信连接器的内容模板以应对不同的使用场景。这里我们以添加单个内容模板举例：
 
 - 用任意字符型内容填写 `content` 栏。不要忘了用 `{{code}}` 占位符为随机生成的验证码预留位置。
-- 用 `Register`，`SignIn`，`ForgotPassword` 或者 `Test` 填入 `usageType` 栏以声明不同的使用场景。为了能够使用完成的流程，需要配置 `usageType` 为 `Register`，`SignIn` 以及 `ForgotPassword` 的模板。
+- 用 `Register`，`SignIn`，`ForgotPassword`，`Generic` 或者 `Test` 填入 `usageType` 栏以声明不同的使用场景。为了能够使用完成的流程，需要配置 `usageType` 为 `Register`，`SignIn` 以及 `ForgotPassword` 的模板。
 
 这是一个 Twilio 短信服务连接器 JSON 配置的样例。
 
@@ -177,19 +181,23 @@ Twilio 提供可编程的通信工具，用于拨打和接听电话、发送和�
     "fromMessagingServiceSID": "<messaging-service-sid>",
     "templates": [
         {
-            "content": "<arbitrary-register-template-contents: your passcode is {{code}}>",
+            "content": "<arbitrary-register-template-contents: your verification code is {{code}}>",
             "usageType": "Register"
         },
         {
-            "content": "<arbitrary-sign-in-template-contents: your passcode is {{code}}>",
+            "content": "<arbitrary-sign-in-template-contents: your verification code is {{code}}>",
             "usageType": "SignIn"
         },
         {
-            "content": "<arbitrary-forgot-password-template-contents: your passcode is {{code}}>",
+            "content": "<arbitrary-forgot-password-template-contents: your verification code is {{code}}>",
             "usageType": "ForgotPassword"
         },
         {
-            "content": "<arbitrary-test-template-contents: your passcode is {{code}}>",
+            "content": "<arbitrary-generic-template-contents: your verification code is {{code}}>",
+            "usageType": "Generic"
+        },
+        {
+            "content": "<arbitrary-test-template-contents: your verification code is {{code}}>",
             "usageType": "Test"
         }
     ]
@@ -214,7 +222,7 @@ Twilio 提供可编程的通信工具，用于拨打和接听电话、发送和�
 | 模板属性   | 类型         | 枚举值                                                |
 |-----------|-------------|------------------------------------------------------|
 | content   | string      | N/A                                                  |
-| usageType | enum string | 'Register' \| 'SignIn' \| 'ForgotPassword' \| 'Test' |
+| usageType | enum string | 'Register' \| 'SignIn' \| 'ForgotPassword' \| 'Generic' \| 'Test' |
 
 ## 参考
 

--- a/packages/connector-twilio-sms/docs/config-template.json
+++ b/packages/connector-twilio-sms/docs/config-template.json
@@ -5,19 +5,23 @@
   "templates": [
     {
       "usageType": "SignIn",
-      "content": "This is for sign-in purposes only. Your passcode is {{code}}."
+      "content": "This is for sign-in purposes only. Your verification code is {{code}}."
     },
     {
       "usageType": "Register",
-      "content": "This is for registering purposes only. Your passcode is {{code}}."
+      "content": "This is for registering purposes only. Your verification code is {{code}}."
     },
     {
       "usageType": "ForgotPassword",
-      "content": "This is for resetting password purposes only. Your passcode is {{code}}."
+      "content": "This is for resetting password purposes only. Your verification code is {{code}}."
+    },
+    {
+      "usageType": "Generic",
+      "content": "This is for generic purposes through management API only. Your verification code is {{code}}."
     },
     {
       "usageType": "Test",
-      "content": "This is for testing purposes only. Your passcode is {{code}}."
+      "content": "This is for testing purposes only. Your verification code is {{code}}."
     }
   ]
 }

--- a/packages/connector-twilio-sms/src/mock.ts
+++ b/packages/connector-twilio-sms/src/mock.ts
@@ -11,7 +11,7 @@ export const mockedConfig: TwilioSmsConfig = {
   templates: [
     {
       usageType: 'Test',
-      content: 'This is for testing purposes only. Your passcode is {{code}}.',
+      content: 'This is for testing purposes only. Your verification code is {{code}}.',
     },
   ],
 };

--- a/packages/connector-twilio-sms/src/types.ts
+++ b/packages/connector-twilio-sms/src/types.ts
@@ -17,7 +17,7 @@ export type PublicParameters = {
 
 /**
  * UsageType here is used to specify the use case of the template, can be either
- * 'Register', 'SignIn', 'ForgotPassword' or 'Test'.
+ * 'Register', 'SignIn', 'ForgotPassword', 'Generic' or 'Test'.
  */
 const requiredTemplateUsageTypes = ['Register', 'SignIn', 'ForgotPassword'];
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
- Add support for `Generic` verification code type in email and SMS connectors
- Drop `passcode` term, use `verification code` instead
- Typo fixes, etc.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Test cases passed
