### PR TITLE
fix: discord user info endpoint returns null for unavailable keys

### DIFF
--- a/.changeset/tiny-cups-double.md
+++ b/.changeset/tiny-cups-double.md
@@ -1,0 +1,5 @@
+---
+"@logto/connector-discord": patch
+---
+
+fix discord user info endpoint parser

--- a/packages/connector-discord/src/types.ts
+++ b/packages/connector-discord/src/types.ts
@@ -1,4 +1,13 @@
+import type { Nullable, Optional } from '@silverhand/essentials';
 import { z } from 'zod';
+
+const nullishToUndefined = <T = unknown>(input: Nullable<T>): Optional<T> => {
+  if (!input) {
+    return;
+  }
+
+  return input;
+};
 
 export const discordConfigGuard = z.object({
   clientId: z.string(),
@@ -18,10 +27,10 @@ export type AccessTokenResponse = z.infer<typeof accessTokenResponseGuard>;
 
 export const userInfoResponseGuard = z.object({
   id: z.string(),
-  username: z.string().optional(),
-  avatar: z.string().optional(),
-  email: z.string().optional(),
-  verified: z.boolean().optional(),
+  username: z.string().nullish().transform(nullishToUndefined),
+  avatar: z.string().nullish().transform(nullishToUndefined),
+  email: z.string().nullish().transform(nullishToUndefined),
+  verified: z.boolean().nullish().transform(nullishToUndefined),
 });
 
 export type UserInfoResponse = z.infer<typeof userInfoResponseGuard>;


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
discord user info endpoint returns null instead of undefined for unavailable keys.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested locally.
