### PR TITLE
refactor: make nameIDFormat type compatible with string array

### DIFF
--- a/.changeset/seven-bobcats-fail.md
+++ b/.changeset/seven-bobcats-fail.md
@@ -1,5 +1,5 @@
 ---
-"@logto/connector-saml": major
+"@logto/connector-saml": minor
 ---
 
-Change `nameIDFormat` from string array to enum, since only some specific values are meaningful. Use enum type instead of string array since only the first element in the array is concerned.
+Change `nameIDFormat`'s preferred type from string array to enum (still compatible to string array, but invalid elements will be filtered).

--- a/packages/connector-saml/src/types.ts
+++ b/packages/connector-saml/src/types.ts
@@ -22,6 +22,10 @@ export enum NameIDFormat {
   Transient = 'urn:oasis:names:tc:SAML:2.0:nameid-format:transient',
 }
 
+const isInNameIdFormatEnum = (input: string) =>
+  // eslint-disable-next-line no-restricted-syntax
+  Object.values(NameIDFormat).includes(input as NameIDFormat);
+
 export const profileMapGuard = z
   .object({
     id: z.string().optional().default('id'),
@@ -63,7 +67,23 @@ export const samlConfigGuard = z
       .nativeEnum(NameIDFormat)
       .optional()
       .default(NameIDFormat.Unspecified)
-      .transform((nameIDFormat) => [nameIDFormat]),
+      .transform((nameIDFormat) => [nameIDFormat])
+      .or(
+        z
+          .string()
+          .array()
+          .transform((stringArray) => {
+            const filteredStringArray = stringArray.filter((element) =>
+              isInNameIdFormatEnum(element)
+            );
+
+            if (filteredStringArray.length === 0) {
+              return [NameIDFormat.Unspecified];
+            }
+
+            return filteredStringArray;
+          })
+      ),
     timeout: z.number().optional().default(defaultTimeout), // In milliseconds.
     authnRequestBinding: z.enum(authnRequestBinding).optional().default('HTTP-Redirect'),
     assertionBinding: z.enum(assertionBinding).optional().default('HTTP-POST'),


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Previously made a change of `nameIDFormat`'s type from a string array to an enum type. This PR makes `nameIDFormat` compatible with a string array (but invalid elements in the array will be filtered).

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested locally.
