### PR TITLE
chore: saml connector config profileMap should be optional

### DIFF
--- a/packages/connector-saml/src/constant.ts
+++ b/packages/connector-saml/src/constant.ts
@@ -142,11 +142,13 @@ export const formItems: ConnectorConfigFormItem[] = [
     label: 'profileMap',
     key: 'profileMap',
     defaultValue: {
-      id: 'nameidentifier',
-      email: 'emailaddress',
-      avatar: 'picture',
+      id: 'id',
+      email: 'email',
+      phone: 'phone',
+      name: 'name',
+      avatar: 'avatar',
     },
-    required: true,
+    required: false,
   },
 ];
 


### PR DESCRIPTION


<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
1. Update SAML connector's profileMap config to be optional.
2. Update the default value of profileMap

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested locally.
