### PR TITLE
feat: support global template for aliyun-sms

### DIFF
--- a/.changeset/thirty-glasses-sit.md
+++ b/.changeset/thirty-glasses-sit.md
@@ -1,0 +1,5 @@
+---
+"@logto/connector-aliyun-sms": minor
+---
+
+Support separating global and China template

--- a/packages/connector-aliyun-sms/src/index.test.ts
+++ b/packages/connector-aliyun-sms/src/index.test.ts
@@ -41,6 +41,39 @@ describe('sendMessage()', () => {
     );
   });
 
+  it('should use template per region', async () => {
+    const connector = await createConnector({ getConfig });
+
+    for (const to of [phoneTest, `86${phoneTest}`, `0086${phoneTest}`, `+86${phoneTest}`]) {
+      // eslint-disable-next-line no-await-in-loop
+      await connector.sendMessage({
+        to,
+        type: VerificationCodeType.Register,
+        payload: { code: codeTest },
+      });
+      expect(sendSms).toHaveBeenCalledWith(
+        expect.objectContaining({
+          TemplateCode: 'TemplateCode1',
+        }),
+        mockedConnectorConfig.accessKeySecret
+      );
+
+      sendSms.mockClear();
+    }
+
+    await connector.sendMessage({
+      to: '+1123123123',
+      type: VerificationCodeType.Register,
+      payload: { code: codeTest },
+    });
+    expect(sendSms).toHaveBeenCalledWith(
+      expect.objectContaining({
+        TemplateCode: 'TemplateCode2',
+      }),
+      mockedConnectorConfig.accessKeySecret
+    );
+  });
+
   it('throws if template is missing', async () => {
     const connector = await createConnector({ getConfig });
     await expect(

--- a/packages/connector-aliyun-sms/src/index.ts
+++ b/packages/connector-aliyun-sms/src/index.ts
@@ -16,8 +16,18 @@ import { HTTPError } from 'got';
 
 import { defaultMetadata } from './constant.js';
 import { sendSms } from './single-send-text.js';
-import type { AliyunSmsConfig } from './types.js';
+import type { AliyunSmsConfig, Template } from './types.js';
 import { aliyunSmsConfigGuard, sendSmsResponseGuard } from './types.js';
+
+const isChinaNumber = (to: string) => /^(\+86|0086|86)?\d{11}$/.test(to);
+
+const getTemplateCode = ({ templateCode }: Template, to: string) => {
+  if (typeof templateCode === 'string') {
+    return templateCode;
+  }
+
+  return isChinaNumber(to) ? templateCode.china : templateCode.overseas;
+};
 
 const sendMessage =
   (getConfig: GetConnectorConfig): SendMessageFunction =>
@@ -39,7 +49,7 @@ const sendMessage =
           AccessKeyId: accessKeyId,
           PhoneNumbers: to,
           SignName: signName,
-          TemplateCode: template.templateCode,
+          TemplateCode: getTemplateCode(template, to),
           TemplateParam: JSON.stringify(payload),
         },
         accessKeySecret

--- a/packages/connector-aliyun-sms/src/mock.ts
+++ b/packages/connector-aliyun-sms/src/mock.ts
@@ -11,7 +11,10 @@ export const mockedConnectorConfig = {
     {
       type: 2,
       usageType: 'Register',
-      templateCode: 'TemplateCode',
+      templateCode: {
+        china: 'TemplateCode1',
+        overseas: 'TemplateCode2',
+      },
     },
     {
       type: 2,

--- a/packages/connector-aliyun-sms/src/types.ts
+++ b/packages/connector-aliyun-sms/src/types.ts
@@ -45,11 +45,13 @@ export type PublicParameters = {
  */
 const requiredTemplateUsageTypes = ['Register', 'SignIn', 'ForgotPassword'];
 
-const templateGuard = z.object({
+export const templateGuard = z.object({
   type: z.nativeEnum(SmsTemplateType).default(2),
   usageType: z.string(),
-  templateCode: z.string(),
+  templateCode: z.string().or(z.object({ china: z.string(), overseas: z.string() })),
 });
+
+export type Template = z.infer<typeof templateGuard>;
 
 export const aliyunSmsConfigGuard = z.object({
   accessKeyId: z.string(),
@@ -61,11 +63,11 @@ export const aliyunSmsConfigGuard = z.object({
         templates.map((template) => template.usageType).includes(requiredType)
       ),
     (templates) => ({
-      message: `Template with UsageType (${requiredTemplateUsageTypes
+      message: `UsageType (${requiredTemplateUsageTypes
         .filter(
           (requiredType) => !templates.map((template) => template.usageType).includes(requiredType)
         )
-        .join(', ')}) should be provided!`,
+        .join(', ')}) should be provided in templates.`,
     })
   ),
 });


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
support separating global and China template. the doc is pending update.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
tested locally, the message sending request segregated as expected

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changset-staged`
- [x] unit tests
- [ ] integration tests
- [ ] docs (pending central update)
